### PR TITLE
fix: flash buffer implementation for arbitrary boards and UNO headers

### DIFF
--- a/examples/flash-example/flash-example.ino
+++ b/examples/flash-example/flash-example.ino
@@ -7,6 +7,7 @@
 
 // buffer which contains the image we want to display, important to use the PROGMEM so it is saved to flash!
 // generated with https://github.com/CamelCaseName/BMP2HUB75
+// alternatively, you can use the python script in ../extras/bmp2hub75.py
 const unsigned char buffer[4096] PROGMEM = {
 
     0, 0, 0, 0, 48, 54, 54, 6, 54, 48, 8, 0, 6, 3, 6, 1, 1, 9, 9, 3, 3, 3, 3, 27, 1, 1, 3, 3, 3, 3, 3, 3, 3, 51, 51, 3, 1, 3, 51, 51, 51, 3, 51, 51, 51, 51, 51, 3, 51, 49, 1, 1, 1, 1, 51, 54, 48, 6, 0, 0, 48, 48, 48, 48,

--- a/extras/bmp2hub75.py
+++ b/extras/bmp2hub75.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# dependencies = ["Pillow"]
+# ///
+
+# ported from https://github.com/CamelCaseName/BMP2HUB75
+# MIT License
+
+import sys
+import os
+
+try:
+    from PIL import Image
+except ImportError:
+    print("Error: The 'Pillow' library is required. Install it using 'pip install Pillow'.")
+    sys.exit(1)
+
+# Generated with wolframalpha "Table[round((1.01093222170971^x)-1), {x,0,255}]"
+# The constant is the 255th root of 16
+RGB8TO4LUT = [
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 
+    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 
+    3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 
+    5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 
+    7, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 9, 9, 9, 9, 9, 9, 9, 9, 9, 10, 10, 10, 10, 10, 
+    10, 10, 10, 11, 11, 11, 11, 11, 11, 11, 11, 12, 12, 12, 12, 12, 12, 12, 13, 13, 13, 13, 13, 13, 
+    14, 14, 14, 14, 14, 14, 14, 15, 15, 15
+]
+
+MAX_COLOR_ITER = 4
+MAX_COLOR_DEPTH = MAX_COLOR_ITER - 1
+
+def die(message):
+    print(message)
+    sys.exit(1)
+
+def rgb8_to_4(color_val):
+    return RGB8TO4LUT[max(0, min(255, int(color_val)))]
+
+def main():
+    if len(sys.argv) <= 1:
+        print("Prints the HUB75 buffer array for the given image.")
+        print("Usage: python bmp2hub75.py <image_path>")
+        return
+
+    image_path = sys.argv[1]
+    
+    if not os.path.exists(image_path):
+        die(f"Error: {image_path} does not exist!")
+
+    try:
+        # Pillow allows reading almost any image format (BMP, PNG, JPG, etc.)
+        img = Image.open(image_path).convert("RGB")
+    except Exception as e:
+        die(f"Error: Failed to open image: {e}")
+
+    width, height = img.size
+    if height % 2 != 0:
+        die("Error: Image height must be even for HUB75 multiplexing.")
+
+    half_height = height // 2
+    pixels = img.load()
+
+    buffer_size = int(height * width * MAX_COLOR_ITER / 2)
+    output = []
+    output.append(f"const unsigned char buffer[{buffer_size}] PROGMEM = {{ ")
+
+    pixels_set = 0
+
+    for i in range(MAX_COLOR_ITER):
+        output.append("\n")
+        bit_pos = MAX_COLOR_DEPTH - i
+        
+        for y in range(half_height):
+            line_data = []
+            for x in range(width):
+                # HUB75 typically drives two rows at once (y and y + half_height)
+                # Upper half pixel (Physical top half)
+                r_u, g_u, b_u = pixels[x, y]
+                # Lower half pixel (Physical bottom half)
+                r_l, g_l, b_l = pixels[x, y + half_height]
+
+                # Convert to 4-bit and extract the current bit plane
+                ru_bit = (rgb8_to_4(r_u) >> bit_pos) & 1
+                gu_bit = (rgb8_to_4(g_u) >> bit_pos) & 1
+                bu_bit = (rgb8_to_4(b_u) >> bit_pos) & 1
+
+                rl_bit = (rgb8_to_4(r_l) >> bit_pos) & 1
+                gl_bit = (rgb8_to_4(g_l) >> bit_pos) & 1
+                bl_bit = (rgb8_to_4(b_l) >> bit_pos) & 1
+
+                # Combine into HUB75 format: 
+                # Bit 5: R Lower, 4: G Lower, 3: B Lower, 2: R Upper, 1: G Upper, 0: B Upper
+                val = (bl_bit << 5) | (gl_bit << 4) | (rl_bit << 3) | (bu_bit << 2) | (gu_bit << 1) | ru_bit
+                line_data.append(f"{val:>2}, ")
+                pixels_set += 1
+            
+            output.append("".join(line_data))
+            output.append("\n")
+
+    # Clean up trailing comma and spaces for a clean C array
+    final_str = "".join(output).rstrip(", \n")
+    final_str += "\n\n};"
+
+    print(f"// Read and converted {pixels_set // MAX_COLOR_ITER * 2} pixels at {width}x{height} and {MAX_COLOR_ITER} bits per channel")
+    print(final_str)
+
+if __name__ == "__main__":
+    main()

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=HUB75nano
-version=2.4.3
+version=2.4.4
 author=Leonhard Seidel
 maintainer=Leonhard Seidel <leonhardseidel@gmx.de>
 sentence=This Library allows the Arduino Nano/Uno/Uno R3/Uno R4 Minima/Nano Every/Mega/Pro Mini to drive a HUB75 panel from 8x16 up to 32x64

--- a/src/boards/board.h
+++ b/src/boards/board.h
@@ -11,8 +11,8 @@
 #pragma GCC warning "this panel size may be too large for the mighty nano ram, please choose a smaller size and let the library simulate bigger pixels"
 #endif
 #else
-#ifdef ARDUINO_AVR_UNO &&defined(__AVR_ATmega328P__)
-#include "boards/uno/uno.h"
+#ifdef ARDUINO_AVR_UNO && defined(__AVR_ATmega328P__)
+#include "boards/nano/nano.h"
 #else
 #ifdef ARDUINO_SAMD_NANO_33_IOT
 #include "boards/iot/iot.h"

--- a/src/boards/board_methods.h
+++ b/src/boards/board_methods.h
@@ -47,7 +47,6 @@
 #endif
 #endif
 #endif
-#endif
 
 #ifndef HIGH_CLK
 #error "this needs to be set for the selected board first"

--- a/src/output/hub75/flash_buffer.h
+++ b/src/output/hub75/flash_buffer.h
@@ -24,21 +24,7 @@ void _displayFlashBuffer()
 #endif
     {
         // we send first the MMSB, then MSB, LSB, LLSB
-#if PANEL_Y > 32
-        index = (buffer_t)(buffer + (y << (uint8_t)7));
-#else
-#if PANEL_Y > 16
-        index = (buffer_t)(buffer + (y << (uint8_t)6));
-#else
-#if PANEL_Y > 8
-        index = (buffer_t)(buffer + (y << (uint8_t)5));
-#else
-#if PANEL_Y > 4
-        index = (buffer_t)(buffer + (y << (uint8_t)4));
-#endif
-#endif
-#endif
-#endif
+        index = ((buffer_t)buffer) + ((uint16_t)y * PANEL_X);
 #ifdef PANEL_FLIP_HORIZONTAL
         index += PANEL_X - 1;
 #endif
@@ -179,7 +165,7 @@ void _displayFlashBuffer()
         Clock;
         _set_color(pgm_read_byte(INDEX_MOVE));
         Clock;
-        _set_color(pgm_read_byte(index));
+        _set_color(pgm_read_byte(INDEX_MOVE));
         Clock;
 #endif
         // shift data into buffers
@@ -201,21 +187,7 @@ void _displayFlashBuffer()
     for (int8_t y = (PANEL_Y / 2) - 1; y >= 0; y--) // 32 rows
 #endif
     {
-#if PANEL_Y > 32
-        index = (buffer_t)(buffer + (y << (uint8_t)7)) + (PANEL_BUFFERSIZE / 4);
-#else
-#if PANEL_Y > 16
-        index = (buffer_t)(buffer + (y << (uint8_t)6)) + (PANEL_BUFFERSIZE / 4);
-#else
-#if PANEL_Y > 8
-        index = (buffer_t)(buffer + (y << (uint8_t)5)) + (PANEL_BUFFERSIZE / 4);
-#else
-#if PANEL_Y > 4
-        index = (buffer_t)(buffer + (y << (uint8_t)4)) + (PANEL_BUFFERSIZE / 4);
-#endif
-#endif
-#endif
-#endif
+        index = ((buffer_t)buffer) + ((uint16_t)y * PANEL_X) + (PANEL_BUFFERSIZE / 4);
 
 #ifdef PANEL_FLIP_HORIZONTAL
         index += PANEL_X - 1;
@@ -356,7 +328,7 @@ void _displayFlashBuffer()
         Clock;
         _set_color(pgm_read_byte(INDEX_MOVE));
         Clock;
-        _set_color(pgm_read_byte(index));
+        _set_color(pgm_read_byte(INDEX_MOVE));
         Clock;
 #endif
         // shift data into buffers
@@ -378,21 +350,7 @@ void _displayFlashBuffer()
     for (int8_t y = (PANEL_Y / 2) - 1; y >= 0; y--) // 32 rows
 #endif
     {
-#if PANEL_Y > 32
-        index = (buffer_t)(buffer + (y << (uint8_t)7)) + (PANEL_BUFFERSIZE / 2);
-#else
-#if PANEL_Y > 16
-        index = (buffer_t)(buffer + (y << (uint8_t)6)) + (PANEL_BUFFERSIZE / 2);
-#else
-#if PANEL_Y > 8
-        index = (buffer_t)(buffer + (y << (uint8_t)5)) + (PANEL_BUFFERSIZE / 2);
-#else
-#if PANEL_Y > 4
-        index = (buffer_t)(buffer + (y << (uint8_t)4)) + (PANEL_BUFFERSIZE / 2);
-#endif
-#endif
-#endif
-#endif
+        index = ((buffer_t)buffer) + ((uint16_t)y * PANEL_X) + (PANEL_BUFFERSIZE / 2);
 #ifdef PANEL_FLIP_HORIZONTAL
         index += PANEL_X - 1;
 #endif
@@ -532,7 +490,7 @@ void _displayFlashBuffer()
         Clock;
         _set_color(pgm_read_byte(INDEX_MOVE));
         Clock;
-        _set_color(pgm_read_byte(index));
+        _set_color(pgm_read_byte(INDEX_MOVE));
         Clock;
 #endif
         // shift data into buffers
@@ -554,21 +512,7 @@ void _displayFlashBuffer()
     for (int8_t y = (PANEL_Y / 2) - 1; y >= 0; y--) // 32 rows
 #endif
     {
-#if PANEL_Y > 32
-        index = (buffer_t)(buffer + (y << (uint8_t)7)) + (PANEL_BUFFERSIZE * 3 / 4);
-#else
-#if PANEL_Y > 16
-        index = (buffer_t)(buffer + (y << (uint8_t)6)) + (PANEL_BUFFERSIZE * 3 / 4);
-#else
-#if PANEL_Y > 8
-        index = (buffer_t)(buffer + (y << (uint8_t)5)) + (PANEL_BUFFERSIZE * 3 / 4);
-#else
-#if PANEL_Y > 4
-        index = (buffer_t)(buffer + (y << (uint8_t)4)) + (PANEL_BUFFERSIZE * 3 / 4);
-#endif
-#endif
-#endif
-#endif
+        index = ((buffer_t)buffer) + ((uint16_t)y * PANEL_X) + ((PANEL_BUFFERSIZE * 3) / 4);
 
 #ifdef PANEL_FLIP_HORIZONTAL
         index += PANEL_X - 1;
@@ -709,7 +653,7 @@ void _displayFlashBuffer()
         Clock;
         _set_color(pgm_read_byte(INDEX_MOVE));
         Clock;
-        _set_color(pgm_read_byte(index));
+        _set_color(pgm_read_byte(INDEX_MOVE));
         Clock;
 #endif
         // shift data into buffers


### PR DESCRIPTION
* Fixed include statements for UNO.
* in `flash_buffer.h`:
  - Fixed an 8-bit wrap-around bug where `(y << N)` overflowed for rows > 7, causing corrupted rendering in Flash Mode on the lower halves of the matrix.
  - Replaced hardcoded `y << N` logic with `16-bit` casted multiplication: `((uint16_t)y * PANEL_X)`. 
  - Removed obsolete `#if PANEL_Y` blocks. The previous logic assumed all panels had a strict `2:1` aspect ratio and incorrectly tied the row width offset to the panel's height.
  - Relying on `y * PANEL_X` allows the compiler to natively optimize to bit-shifts while fully supporting arbitrary panel aspect ratios (like 1:1 or 4:1) safely.
  - Fixed a missing index increment at the end of the unrolled loops.
* add simple python script to generate flash example buffer